### PR TITLE
Allow script to be run directly using `uv run`

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = [ "fastmcp", "httpx" ]
+# ///
+
 import httpx
 from typing import List, Optional
 from mcp.server.fastmcp import FastMCP


### PR DESCRIPTION
Add support for [pep-0723](https://peps.python.org/pep-0723/#example) to enable `uv run jadx_mcp_server.py` to automatically download the required dependencies.

If accepted, users won't need to set up the environment as described here: https://github.com/zinja-coder/jadx-ai-mcp/blob/jadx-ai/README.md?plain=1#L175-L178; `uv run` will handle it all at once.