### PR TITLE
fix(get_android_manifest) : Sometimes TypeError

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -11,6 +11,7 @@ See the file 'LICENSE' for copying permission
 import httpx
 import logging
 import argparse
+import json
 
 from typing import List, Union
 from mcp.server.fastmcp import FastMCP
@@ -238,7 +239,10 @@ async def get_android_manifest() -> dict:
     Returns:
         Dictionary containing content of AndroidManifest.xml file.
     """
-    return await get_from_jadx("manifest")
+    manifest = await get_from_jadx("manifest")
+    if isinstance(manifest, str):
+        return json.loads(manifest)
+    return manifest
 
 @mcp.tool(name="get_strings", description="Retrieve contents of strings.xml files that exists in application.")
 async def get_strings() -> dict:


### PR DESCRIPTION
# Pull Request

## Related Issues

```bash
[09/02/25 16:54:12] ERROR    Error calling tool 'get_android_manifest'                           tool_manager.py:231
                             ╭─────────────── Traceback (most recent call last) ───────────────╮                    
                             │ /opt/homebrew/lib/python3.12/site-packages/fastmcp/tools/tool_m │                    
                             │ anager.py:222 in call_tool                                      │                    
                             │                                                                 │                    
                             │   219 │   │   │   │   raise NotFoundError(f"Tool {key!r} not fo │                    
                             │   220 │   │   │                                                 │                    
                             │   221 │   │   │   try:                                          │                    
                             │ ❱ 222 │   │   │   │   return await tool.run(arguments)          │                    
                             │   223 │   │   │                                                 │                    
                             │   224 │   │   │   # raise ToolErrors as-is                      │                    
                             │   225 │   │   │   except ToolError as e:                        │                    
                             │                                                                 │                    
                             │ /opt/homebrew/lib/python3.12/site-packages/fastmcp/tools/tool.p │                    
                             │ y:323 in run                                                    │                    
                             │                                                                 │                    
                             │   320 │   │   │   except Exception:                             │                    
                             │   321 │   │   │   │   pass                                      │                    
                             │   322 │   │                                                     │                    
                             │ ❱ 323 │   │   return ToolResult(                                │                    
                             │   324 │   │   │   content=unstructured_result,                  │                    
                             │   325 │   │   │   structured_content=structured_output,         │                    
                             │   326 │   │   )                                                 │                    
                             │                                                                 │                    
                             │ /opt/homebrew/lib/python3.12/site-packages/fastmcp/tools/tool.p │                    
                             │ y:83 in __init__                                                │                    
                             │                                                                 │                    
                             │    80 │   │   │   │   )                                         │                    
                             │    81 │   │   │   │   raise                                     │                    
                             │    82 │   │   │   if not isinstance(structured_content, dict):  │                    
                             │ ❱  83 │   │   │   │   raise ValueError(                         │                    
                             │    84 │   │   │   │   │   "structured_content must be a dict or │                    
                             │    85 │   │   │   │   │   f"Got {type(structured_content).__nam │                    
                             │    86 │   │   │   │   │   "Tools should wrap non-dict values ba │                    
                             ╰─────────────────────────────────────────────────────────────────╯                    
                             ValueError: structured_content must be a dict or None. Got str:                        
                             '{"name":"AndroidManifest.xml","type":"manifest/xml","content":"<?x                    
                             ml version=\\"1.0\\" encoding=\\"utf-8\\"?>\\n<manifest                                
                             xmlns:android=\\"http://schemas.android.com/apk/res/android\\"\\n                      
                             android:versionCode=\\"100001\\"\\n                                                    
                             android:versionName=\\"1.0\\"\\n                                                       
                             android:compileSdkVersion=\\"29\\"\\n                                                  
                             android:compileSdkVersionCodename=\\"10\\"\\n                                          
                             package=\\"com.iee3b00cb99786f4d\\"\\n                                                 
                             platformBuildVersionCode=\\"29\\"\\n                                                   
                             platformBuildVersionName=\\"10\\">\\n    <uses-sdk\\n                                  
                             android:minSdkVersion=\\"16\\"\\n                                                      
                             android:targetSdkVersion=\\"29\\"/>\\n    <uses-permission                             
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"android.permission.MANAGE_EXTERNAL_STORAGE\\"/>\\n                     
                             <uses-permission android:name=\\"\\"/>\\n    <uses-feature                             
                             android:name=\\"\\"/>\\n    <uses-feature android:name=\\"\\"/>\\n                     
                             <uses-feature android:name=\\"\\"/>\\n    <uses-feature                                
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"\\"/>\\n    <uses-permission                                           
                             android:name=\\"android.permission.REQUEST_INSTALL_PACKAGES\\"/>\\n                    
                             <uses-permission android:name=\\"\\"/>\\n    <application\\n                           
                             android:theme=\\"@style/Theme.V6Application\\"\\n                                      
                             android:label=\\"安卓签到\\"\\n                                                        
                             android:icon=\\"@mipmap/i\\"\\n                                                        
                             android:allowBackup=\\"true\\"\\n                                                      
                             android:hardwareAccelerated=\\"true\\"\\n                                              
                             android:largeHeap=\\"true\\"\\n                                                        
                             android:supportsRtl=\\"true\\"\\n                                                      
                             android:usesCleartextTraffic=\\"true\\"\\n                                             
                             android:resizeableActivity=\\"true\\"\\n                                               
                             android:networkSecurityConfig=\\"@xml/network_config\\"\\n                             
                             android:requestLegacyExternalStorage=\\"true\\">\\n                                    
                             <meta-data\\n            android:name=\\"android.max_aspect\\"\\n                      
                             android:value=\\"2.1\\"/>\\n        <activity\\n                                       
                             android:name=\\"i6.app.iActivity\\"\\n                                                 
                             android:configChanges=\\"screenSize|orientation|keyboardHidden\\">\                    
                             \n            <intent-filter>\\n                <action                                
                             android:name=\\"android.intent.action.MAIN\\"/>\\n                                     
                             <category android:name=\\"android.intent.category.LAUNCHER\\"/>\\n                     
                             </intent-filter>\\n        </activity>\\n        <provider\\n                          
                             android:name=\\"i.app.FileProvider\\"\\n                                               
                             android:exported=\\"false\\"\\n                                                        
                             android:authorities=\\"com.iee3b00cb99786f4d.myFileProvider\\"\\n                      
                             android:grantUriPermissions=\\"true\\">\\n            <meta-data\\n                    
                             android:name=\\"android.support.FILE_PROVIDER_PATHS\\"\\n                              
                             android:resource=\\"@xml/file_provider\\"/>\\n                                         
                             </provider>\\n        <meta-data\\n                                                    
                             android:name=\\"android.support.VERSION\\"\\n                                          
                             android:value=\\"26.1.0\\"/>\\n        <meta-data\\n                                   
                             android:name=\\"android.arch.lifecycle.VERSION\\"\\n                                   
                             android:value=\\"27.0.0-SNAPSHOT\\"/>\\n                                               
                             </application>\\n</manifest>"}'. Tools should wrap non-dict values                     
                             based on their output_schema. 
```

## Summary of Changes
<!-- Provide a short summary of what you changed or added -->

fix a bug
