### PR TITLE
fix: get_method_by_name return str instead of dict

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -235,7 +235,7 @@ async def get_selected_text() -> str:
     return await get_from_jadx("selected-text")
 
 @mcp.tool()
-async def get_method_by_name(class_name: str, method_name: str) -> dict:
+async def get_method_by_name(class_name: str, method_name: str) -> str:
     """Fetch the source code of a method from a specific class.
     
     Args:


### PR DESCRIPTION
# Pull Request

the implement of handleMethodByName return json result as follow
<img width="793" height="203" alt="image" src="https://github.com/user-attachments/assets/c9c65f6e-019a-4efb-8769-dc7b79906119" />
but the python mcp server return dict which is not valid

## Summary of Changes
<!-- Provide a short summary of what you changed or added -->

- fix  get_method_by_name return error


