### PR TITLE
Use PaginationUtils.DEFAULT_PAGE_SIZE instead of DEFAULT_PAGE_SIZE

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -160,7 +160,7 @@ class PaginationUtils:
     @staticmethod
     def create_page_based_tool(base_func: Callable) -> Callable:
         """Decorator to create page-based versions of offset-based functions"""
-        async def page_wrapper(page: int = 1, page_size: int = DEFAULT_PAGE_SIZE, **kwargs) -> dict:
+        async def page_wrapper(page: int = 1, page_size: int = PaginationUtils.DEFAULT_PAGE_SIZE, **kwargs) -> dict:
             page = max(1, page)
             page_size = max(1, min(page_size, PaginationUtils.MAX_PAGE_SIZE))
             offset = (page - 1) * page_size


### PR DESCRIPTION
# Pull Request

## Related Issues
<!-- Link to related issues if applicable -->
Closes #

## Summary of Changes
<!-- Provide a short summary of what you changed or added -->
On line 163 in the decorator page_wrapper I replaced DEFAULT_PAGE_SIZE with PaginationUtils.DEFAULT_PAGE_SIZE in the default function arguments
- 
- 
- 

## Testing
<!-- Describe how you tested your changes -->

- [x] Ran all existing tests
- [ ] Added new tests
- [x] Manually tested features

## Checklist
- [x] My code follows the project’s coding style.
- [ ] I have added tests that prove my fix/feature works.
- [ ] I have updated documentation where necessary.
- [x] My changes do not break existing functionality.
- [ ] I have rebased on the latest `main` branch.

## Additional Notes
<!-- Any extra information or context -->
