### PR TITLE
add mcp tool:search_classes_by_keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The following MCP tools are available:
 - `get_class_source()` — Get full source of a given class
 - `get_method_by_name()` — Fetch a method’s source
 - `search_method_by_name()` — Search method across classes
+- `search_classes_by_keyword()` — Search for classes whose source code contains a specific keyword (supports pagination)
 - `get_methods_of_class()` — List methods in a class
 - `get_fields_of_class()` — List fields in a class
 - `get_smali_of_class()` — Fetch smali of class

--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -188,6 +188,28 @@ async def get_methods_of_class(class_name: str) -> dict:
     return await get_from_jadx("methods-of-class", {"class_name": class_name})
 
 @mcp.tool()
+async def search_classes_by_keyword(search_term:str, offset: int = 0, count: int = 20) -> dict:
+    """searching for classes whose source code contains a specific keyword, 
+    with pagination support for handling large result sets efficiently.
+    
+    Args:
+        search_term: query keyword
+        offset: Offset to start listing from (start at 0)
+        count: Number of classes to return (default 20)
+    
+    Returns:
+        A dictionary containing paginated class list and metadata.
+    """
+    return await PaginationUtils.get_paginated_data(
+        endpoint="search-classes-by-keyword",
+        offset=offset,
+        count=count,
+        additional_params={"search_term": search_term},
+        data_extractor=lambda parsed: parsed.get("classes", []),
+        fetch_function=get_from_jadx
+    )
+
+@mcp.tool()
 async def get_fields_of_class(class_name: str) -> dict:
     """List all field names in a class.
     


### PR DESCRIPTION
# Feature: Implement Class Search by Keyword with Pagination

## Description

This PR introduces the `search_classes_by_keyword` capability to the JADX MCP server. This feature enables users to search for classes based on specific keywords within the codebase, significantly improving navigation and discovery in large projects.

## Key Features

- **Keyword-Based Search**: Users can now query for classes containing specific terms.
- **Pagination Support**: Integrated with `PaginationUtils` to handle large result sets efficiently using `offset` and `limit`.

## Implementation Details

The `search_classes_by_keyword` tool is implemented using the existing pagination infrastructure:
- **Endpoint**: Targets the `search-classes-by-keyword` endpoint of the JADX plugin.
- **Parameter Handling**: Correctly passes `search_term` via `additional_params` to the pagination utility.
- **Data Extraction**: Automatically extracts the class list from the response payload.

## Testing
I have run the modified **jadx_mcp_server.py** code and tested it with my cursor agent. The prompt was:
```please search all classes include defa and show top 20 classes```
The agent successfully called the **search_classes_by_keyword** tool and it worked as expected.