### PR TITLE
enhance handleMainApplicationClassesCode

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -20,7 +20,7 @@ mcp = FastMCP("JADX-AI-MCP Plugin Reverse Engineering Server")
 
 # Import and register ALL tools using correct FastMCP pattern
 from src.server.tools.class_tools import (
-    fetch_current_class, get_selected_text, get_class_source, 
+    fetch_current_class, get_selected_text, get_class_source,
     get_all_classes, get_methods_of_class, get_fields_of_class, get_smali_of_class,
     get_main_application_classes_names, get_main_application_classes_code, get_main_activity_class
 )
@@ -28,7 +28,7 @@ from src.server.tools.search_tools import (
     get_method_by_name, search_method_by_name, search_classes_by_keyword
 )
 from src.server.tools.resource_tools import (
-    get_android_manifest, get_strings, get_all_resource_file_names, 
+    get_android_manifest, get_strings, get_all_resource_file_names,
     get_resource_file
 )
 from src.server.tools.refactor_tools import (
@@ -41,157 +41,257 @@ from src.server.tools.xrefs_tools import (
     get_xrefs_to_class, get_xrefs_to_method, get_xrefs_to_field
 )
 
+
 # CORRECT REGISTRATION PATTERN for FastMCP
 @mcp.tool()
 async def fetch_current_class() -> dict:
     """Fetch the currently selected class and its code from the JADX-GUI plugin."""
     return await tools.class_tools.fetch_current_class()
 
+
 @mcp.tool()
 async def get_selected_text() -> dict:
     """Returns the currently selected text in the decompiled code view."""
     return await tools.class_tools.get_selected_text()
+
 
 @mcp.tool()
 async def get_method_by_name(class_name: str, method_name: str) -> dict:
     """Fetch the source code of a method from a specific class."""
     return await tools.search_tools.get_method_by_name(class_name, method_name)
 
+
 @mcp.tool()
 async def get_all_classes(offset: int = 0, count: int = 0) -> dict:
     """Returns a list of all classes in the project with pagination support."""
     return await tools.class_tools.get_all_classes(offset, count)
+
 
 @mcp.tool()
 async def get_class_source(class_name: str) -> dict:
     """Fetch the Java source of a specific class."""
     return await tools.class_tools.get_class_source(class_name)
 
+
 @mcp.tool()
 async def search_method_by_name(method_name: str) -> dict:
     """Search for a method name across all classes."""
     return await tools.search_tools.search_method_by_name(method_name)
+
 
 @mcp.tool()
 async def get_methods_of_class(class_name: str) -> dict:
     """List all method names in a class."""
     return await tools.class_tools.get_methods_of_class(class_name)
 
+
 @mcp.tool()
-async def search_classes_by_keyword(search_term: str, offset: int = 0, count: int = 20) -> dict:
-    """Search for classes whose source code contains a specific keyword."""
-    return await tools.search_tools.search_classes_by_keyword(search_term, offset, count)
+async def search_classes_by_keyword(
+    search_term: str,
+    package: str = "",
+    search_in: str = "code",
+    offset: int = 0,
+    count: int = 20,
+) -> dict:
+    """Search for classes containing a specific keyword with flexible filtering options.
+
+    This tool performs a comprehensive search across decompiled Android code, allowing you to:
+    1. Search within specific packages by providing a package name
+    2. Target specific search scopes (class names, method names, fields, code content, comments)
+    3. Combine multiple search scopes for precise results
+
+    Args:
+        search_term: The keyword or string to search for. This is the main search query.
+
+        package (optional): Package name to limit the search scope.
+            - If empty string (default), searches across all packages in the APK
+            - If provided, only searches within classes belonging to the specified package
+            - Example: "com.example.app" to search only in that package
+
+        search_in (optional): Comma-separated list of search scopes to target.
+            Valid values:
+            - "class": Search in class names only
+            - "method": Search in method names only
+            - "field": Search in field names only
+            - "code": Search in code content (method bodies, statements, etc.)
+            - "comment": Search in comments
+
+            You can specify one or multiple scopes:
+            - Single scope: "class" (only class names)
+            - Multiple scopes: "class,method" (class names OR method names)
+            - Combined: "class,method,code" (searches in all three scopes)
+
+            Default: "code" (searches in code content)
+
+        offset (optional): Starting index for pagination. Default: 0
+        count (optional): Maximum number of results to return. Default: 20
+
+    Returns:
+        dict: Paginated list of classes containing the search term, with metadata about matches
+
+    MCP Tool: search_classes_by_keyword
+    Description: Advanced search tool that finds classes matching a keyword with package filtering
+                 and scope targeting capabilities. Use this when you need to find specific code
+                 patterns, class names, method names, or other identifiers across the decompiled APK."""
+    return await tools.search_tools.search_classes_by_keyword(
+        search_term, package, search_in, offset, count
+    )
+
 
 @mcp.tool()
 async def get_fields_of_class(class_name: str) -> dict:
     """List all field names in a class."""
     return await tools.class_tools.get_fields_of_class(class_name)
 
+
 @mcp.tool()
 async def get_smali_of_class(class_name: str) -> dict:
     """Fetch the smali representation of a class."""
     return await tools.class_tools.get_smali_of_class(class_name)
+
 
 @mcp.tool()
 async def get_android_manifest() -> dict:
     """Retrieve and return the AndroidManifest.xml content."""
     return await tools.resource_tools.get_android_manifest()
 
+
 @mcp.tool()
 async def get_strings(offset: int = 0, count: int = 0) -> dict:
     """Retrieve contents of strings.xml files."""
     return await tools.resource_tools.get_strings(offset, count)
+
 
 @mcp.tool()
 async def get_all_resource_file_names(offset: int = 0, count: int = 0) -> dict:
     """Retrieve all resource files names."""
     return await tools.resource_tools.get_all_resource_file_names(offset, count)
 
+
 @mcp.tool()
 async def get_resource_file(resource_name: str) -> dict:
     """Retrieve resource file content."""
     return await tools.resource_tools.get_resource_file(resource_name)
+
 
 @mcp.tool()
 async def get_main_application_classes_names() -> dict:
     """Fetch main application classes' names from Manifest package."""
     return await tools.class_tools.get_main_application_classes_names()
 
+
 @mcp.tool()
 async def get_main_application_classes_code(offset: int = 0, count: int = 0) -> dict:
     """Fetch main application classes' code with pagination."""
     return await tools.class_tools.get_main_application_classes_code(offset, count)
+
 
 @mcp.tool()
 async def get_main_activity_class() -> dict:
     """Fetch the main activity class from AndroidManifest.xml."""
     return await tools.class_tools.get_main_activity_class()
 
+
 @mcp.tool()
 async def rename_class(class_name: str, new_name: str) -> dict:
     """Renames a specific class."""
     return await tools.refactor_tools.rename_class(class_name, new_name)
+
 
 @mcp.tool()
 async def rename_method(method_name: str, new_name: str) -> dict:
     """Renames a specific method."""
     return await tools.refactor_tools.rename_method(method_name, new_name)
 
+
 @mcp.tool()
 async def rename_field(class_name: str, field_name: str, new_name: str) -> dict:
     """Renames a specific field."""
     return await tools.refactor_tools.rename_field(class_name, field_name, new_name)
+
 
 @mcp.tool()
 async def rename_package(old_package_name: str, new_package_name: str) -> dict:
     """Renames a package and all its classes."""
     return await tools.refactor_tools.rename_package(old_package_name, new_package_name)
 
+
 @mcp.tool()
 async def debug_get_stack_frames() -> dict:
     """Get current stack frames (call stack)."""
     return await tools.debug_tools.debug_get_stack_frames()
+
 
 @mcp.tool()
 async def debug_get_threads() -> dict:
     """Get all threads in the debugged process."""
     return await tools.debug_tools.debug_get_threads()
 
+
 @mcp.tool()
 async def debug_get_variables() -> dict:
     """Get current variables when process is suspended."""
     return await tools.debug_tools.debug_get_variables()
+
 
 @mcp.tool()
 async def get_xrefs_to_class(class_name: str, offset: int = 0, count: int = 20) -> dict:
     """Find all references to a class."""
     return await tools.xrefs_tools.get_xrefs_to_class(class_name, offset, count)
 
-@mcp.tool()
-async def get_xrefs_to_method(class_name: str, method_name: str, offset: int = 0, count: int = 20) -> dict:
-    """Find all references to a method."""
-    return await tools.xrefs_tools.get_xrefs_to_method(class_name, method_name, offset, count)
 
 @mcp.tool()
-async def get_xrefs_to_field(class_name: str, field_name: str, offset: int = 0, count: int = 20) -> dict:
+async def get_xrefs_to_method(
+    class_name: str, method_name: str, offset: int = 0, count: int = 20
+) -> dict:
+    """Find all references to a method."""
+    return await tools.xrefs_tools.get_xrefs_to_method(
+        class_name, method_name, offset, count
+    )
+
+
+@mcp.tool()
+async def get_xrefs_to_field(
+    class_name: str, field_name: str, offset: int = 0, count: int = 20
+) -> dict:
     """Find all references to a field."""
-    return await tools.xrefs_tools.get_xrefs_to_field(class_name, field_name, offset, count)
+    return await tools.xrefs_tools.get_xrefs_to_field(
+        class_name, field_name, offset, count
+    )
+
 
 def main():
     parser = argparse.ArgumentParser("MCP Server for Jadx")
-    parser.add_argument("--http", help="Serve MCP Server over HTTP stream.", action="store_true", default=False)
-    parser.add_argument("--port", help="Port for --http (default:8651)", default=8651, type=int)
-    parser.add_argument("--jadx-port", help="JADX AI MCP Plugin port (default:8650)", default=8650, type=int)
+    parser.add_argument(
+        "--http",
+        help="Serve MCP Server over HTTP stream.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--port", help="Port for --http (default:8651)", default=8651, type=int
+    )
+    parser.add_argument(
+        "--jadx-port",
+        help="JADX AI MCP Plugin port (default:8650)",
+        default=8650,
+        type=int,
+    )
     args = parser.parse_args()
 
     # Configure
     config.set_jadx_port(args.jadx_port)
-    
+
     # Banner & Health Check
     try:
         print(jadx_mcp_server_banner())
     except:
-        print("[JADX AI MCP Server] v3.3.5 | MCP Port:", args.port, "| JADX Port:", args.jadx_port)
+        print(
+            "[JADX AI MCP Server] v3.3.5 | MCP Port:",
+            args.port,
+            "| JADX Port:",
+            args.jadx_port,
+        )
 
     print("Testing JADX AI MCP Plugin connectivity...")
     result = config.health_ping()
@@ -202,6 +302,7 @@ def main():
         mcp.run(transport="streamable-http", port=args.port)
     else:
         mcp.run()
+
 
 if __name__ == "__main__":
     main()

--- a/src/server/tools/search_tools.py
+++ b/src/server/tools/search_tools.py
@@ -26,7 +26,9 @@ async def get_method_by_name(class_name: str, method_name: str) -> dict:
     MCP Tool: get_method_by_name
     Description: Retrieves specific method implementation from a known class
     """
-    return await get_from_jadx("method-by-name", {"class_name": class_name, "method_name": method_name})
+    return await get_from_jadx(
+        "method-by-name", {"class_name": class_name, "method_name": method_name}
+    )
 
 
 async def search_method_by_name(method_name: str) -> dict:
@@ -45,26 +47,65 @@ async def search_method_by_name(method_name: str) -> dict:
     return await get_from_jadx("search-method", {"method_name": method_name})
 
 
-async def search_classes_by_keyword(search_term: str, offset: int = 0, count: int = 20) -> dict:
+async def search_classes_by_keyword(
+    search_term: str,
+    package: str = "",
+    search_in: str = "code",
+    offset: int = 0,
+    count: int = 20,
+) -> dict:
     """
-    Search for classes whose source code contains a specific keyword.
+    Search for classes containing a specific keyword with flexible filtering options.
+
+    This tool performs a comprehensive search across decompiled Android code, allowing you to:
+    1. Search within specific packages by providing a package name
+    2. Target specific search scopes (class names, method names, fields, code content, comments)
+    3. Combine multiple search scopes for precise results
 
     Args:
-        search_term: Keyword or string to search for in class source code
-        offset: Starting index for pagination (default: 0)
-        count: Number of results to return (default: 20)
+        search_term: The keyword or string to search for. This is the main search query.
+
+        package (optional): Package name to limit the search scope.
+            - If empty string (default), searches across all packages in the APK
+            - If provided, only searches within classes belonging to the specified package
+            - Example: "com.example.app" to search only in that package
+
+        search_in (optional): Comma-separated list of search scopes to target.
+            Valid values:
+            - "class": Search in class names only
+            - "method": Search in method names only
+            - "field": Search in field names only
+            - "code": Search in code content (method bodies, statements, etc.)
+            - "comment": Search in comments
+
+            You can specify one or multiple scopes:
+            - Single scope: "class" (only class names)
+            - Multiple scopes: "class,method" (class names OR method names)
+            - Combined: "class,method,code" (searches in all three scopes)
+
+            Default: "code" (searches in code content)
+
+        offset (optional): Starting index for pagination. Default: 0
+        count (optional): Maximum number of results to return. Default: 20
 
     Returns:
-        dict: Paginated list of classes containing the search term
+        dict: Paginated list of classes containing the search term, with metadata about matches
 
     MCP Tool: search_classes_by_keyword
-    Description: Performs full-text search across all decompiled class code
+    Description: Advanced search tool that finds classes matching a keyword with package filtering
+                 and scope targeting capabilities. Use this when you need to find specific code
+                 patterns, class names, method names, or other identifiers across the decompiled APK.
+
     """
     return await PaginationUtils.get_paginated_data(
         endpoint="search-classes-by-keyword",
         offset=offset,
         count=count,
-        additional_params={"search_term": search_term},
+        additional_params={
+            "search_term": search_term,
+            "package": package,
+            "search_in": search_in,
+        },
         data_extractor=lambda parsed: parsed.get("classes", []),
-        fetch_function=get_from_jadx
+        fetch_function=get_from_jadx,
     )


### PR DESCRIPTION
# Enhance `handleSearchClassesByKeyword` with Package Filtering and Multi-Location Search

## Summary

This PR enhances the `handleSearchClassesByKeyword` method in `ClassRoutes.java` to support:
1. **Package filtering** - Limit search scope to specific packages with special handling for jadx obfuscated packages
2. **Multi-location search** - Search across multiple locations (class names, method names, field names, code, comments) with URL-friendly lowercase parameters
3. **Improved method search** - Match jadx's search behavior by including method names, constructor names, and parameter types

## Changes

### 1. Added Package Filtering Support

- Added optional `package` query parameter to limit search to specific packages
- Implemented special handling for jadx obfuscated packages:
  - Detects and skips filtering for packages matching pattern `p000`, `p001`, etc. (jadx's obfuscated package naming)
  - Detects and skips filtering for `defpackage` (default package for obfuscated classes)

### 2. Enhanced Search Location Support

- Introduced `SearchLocation` enum with values:
  - `CLASS_NAME` - Search by class name
  - `METHOD_NAME` - Search by method name, constructor, and parameter types
  - `FIELD_NAME` - Search by field name
  - `CODE` - Search in code content (default)
  - `COMMENT` - Search in comments
- Added `SEARCH_LOCATION_MAP` HashMap for URL-friendly lowercase parameter parsing
- Supports both short names (`class`, `method`, `field`, `code`, `comment`) and full names (`class_name`, `method_name`, `field_name`)
- Supports multi-select: users can specify multiple search locations (e.g., `search_in=class,method,code`)
- Results are automatically deduplicated using `LinkedHashSet` to maintain order

### 3. Improved Method Search Implementation

- Enhanced `searchByMethodName()` to match jadx's search behavior:
  - Searches method names (including `<init>` and `<clinit>`)
  - Searches constructor names by matching against class simple name

### 4. Code Organization

- Refactored search logic into dedicated helper methods:
  - `searchByClassName()` - Class name search
  - `searchByMethodName()` - Method/constructor/parameter search
  - `searchByFieldName()` - Field name search
  - `searchByCode()` - Code content search
  - `searchByComment()` - Comment search with regex pattern matching
- Added `searchInLocation()` method to route searches to appropriate helper methods
- Maintained consistent code style with existing codebase
- Added comprehensive JavaDoc comments for all new methods

## API Changes

### New Query Parameters

- `package` (optional): Package name to filter search results
  - Example: `package=com.example.app`
  - Special handling: Automatically disabled for obfuscated packages (`p000`, `p001`, `defpackage`)

- `search_in` (optional): Comma-separated list of search locations
  - Valid values: `class`, `class_name`, `method`, `method_name`, `field`, `field_name`, `code`, `comment`
  - Default: `code` (if not specified)
  - Example: `search_in=class,method,code`
  - Case-insensitive, accepts lowercase values for URL-friendly usage

### Example Usage

```bash
# Search in code only (default behavior, backward compatible)
GET /search-classes-by-keyword?search_term=login

# Search in class names and methods within specific package
GET /search-classes-by-keyword?search_term=login&package=com.example.app&search_in=class,method

# Multi-location search across all locations
GET /search-classes-by-keyword?search_term=api&search_in=class,method,field,code,comment

# Package filter automatically disabled for obfuscated packages
GET /search-classes-by-keyword?search_term=test&package=p000.some.package
# Will log: "Package filter 'p000.some.package' appears to be a jadx obfuscated package name, skipping package filtering"
```

## Backward Compatibility

- All changes are backward compatible
- Default behavior unchanged: if `search_in` is not specified, searches in `CODE` location (original behavior)
- Existing API calls without new parameters continue to work as before

## Testing

- Code compiles successfully with Maven
- Package filtering gracefully handles obfuscated package names