### PR TITLE
add add_comment tool support

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -32,7 +32,7 @@ from src.server.tools.resource_tools import (
     get_resource_file
 )
 from src.server.tools.refactor_tools import (
-    rename_class, rename_method, rename_field, rename_package, rename_variable
+    rename_class, rename_method, rename_field, rename_package, rename_variable, add_comment
 )
 from src.server.tools.debug_tools import (
     debug_get_stack_frames, debug_get_threads, debug_get_variables
@@ -220,6 +220,12 @@ async def rename_package(old_package_name: str, new_package_name: str) -> dict:
 async def rename_variable(class_name: str, method_name: str, variable_name: str, new_name: str, reg: str = None, ssa: str = None) -> dict:
     """Renames a specific variable in a method."""
     return await tools.refactor_tools.rename_variable(class_name, method_name, variable_name, new_name, reg, ssa)
+
+
+@mcp.tool()
+async def add_comment(target_type: str, class_name: str, comment: str, method_name: str = None, field_name: str = None, style: str = "LINE") -> dict:
+    """Adds a comment to a class, method, or field in the decompiled code with customizable comment style."""
+    return await tools.refactor_tools.add_comment(target_type, class_name, comment, method_name, field_name, style)
 
 
 @mcp.tool()

--- a/src/server/tools/refactor_tools.py
+++ b/src/server/tools/refactor_tools.py
@@ -118,3 +118,57 @@ async def rename_variable(class_name: str, method_name: str, variable_name: str,
         params["ssa"] = ssa
 
     return await get_from_jadx("rename-variable", params)
+
+
+async def add_comment(target_type: str, class_name: str, comment: str, method_name: str = None, field_name: str = None, style: str = "LINE") -> dict:
+    """
+    Adds a comment to a class, method, or field in the decompiled code.
+
+    Args:
+        target_type: Type of target ("class", "method", or "field")
+        class_name: Fully qualified class name
+        comment: The comment text to add
+        method_name (optional): Method name (required for method comments, can include full signature for overloaded methods)
+        field_name (optional): Field name (required for field comments)
+        style (optional): Comment style (default: "LINE")
+            - "LINE": Single-line comment (// comment)
+            - "BLOCK": Multi-line block comment (/* comment */)
+            - "BLOCK_CONDENSED": Condensed block comment (/* comment */)
+            - "JAVADOC": Javadoc style (/** comment */)
+            - "JAVADOC_CONDENSED": Condensed Javadoc (/** comment */)
+
+    Returns:
+        dict: Confirmation of comment addition with style information
+
+    MCP Tool: add_comment
+    Description: Adds explanatory comments to decompiled code elements (classes, methods, or fields) with customizable comment styles
+    
+    Examples:
+        # Add single-line comment to a class (default style)
+        add_comment("class", "com.example.MyClass", "This class handles user authentication")
+        
+        # Add block comment to a method
+        add_comment("method", "com.example.MyClass", "Validates user credentials\\nChecks password hash\\nReturns auth token", 
+                   method_name="validateUser", style="BLOCK")
+        
+        # Add Javadoc to overloaded method
+        add_comment("method", "com.example.MyClass", "Validates user with email\\n@param email User email\\n@return true if valid", 
+                   method_name="com.example.MyClass.validateUser(java.lang.String):boolean",
+                   style="JAVADOC")
+        
+        # Add comment to a field
+        add_comment("field", "com.example.MyClass", "User session token", field_name="sessionToken", style="LINE")
+    """
+    params = {
+        "target_type": target_type,
+        "class_name": class_name,
+        "comment": comment,
+        "style": style
+    }
+    
+    if method_name:
+        params["method_name"] = method_name
+    if field_name:
+        params["field_name"] = field_name
+
+    return await get_from_jadx("add-comment", params)


### PR DESCRIPTION
## Summary
- Add MCP tool wrapper for the `add_comment` HTTP endpoint
- Support adding comments to classes, methods, and fields in decompiled code
- Support customizable comment styles (LINE, BLOCK, JAVADOC, etc.)

## Test plan
- [x] Tested with jadx-ai-mcp plugin
- [x] Verified add_comment works for class, method, and field targets