### PR TITLE
fix: resolve search timeout on large APKs with progress polling and server-alive detection

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -32,7 +32,8 @@ logger.propagate = False
 from src.server.tools.class_tools import (
     fetch_current_class, get_selected_text, get_class_source,
     get_all_classes, get_methods_of_class, get_fields_of_class, get_smali_of_class,
-    get_main_application_classes_names, get_main_application_classes_code, get_main_activity_class
+    get_main_application_classes_names, get_main_application_classes_code, get_main_activity_class,
+    get_package_tree, get_cache_stats, clear_cache
 )
 from src.server.tools.search_tools import (
     get_method_by_name, search_method_by_name, search_classes_by_keyword
@@ -210,6 +211,24 @@ async def get_main_application_classes_code(offset: int = 0, count: int = 0) -> 
 async def get_main_activity_class() -> dict:
     """Fetch the main activity class from AndroidManifest.xml."""
     return await tools.class_tools.get_main_activity_class()
+
+
+@mcp.tool()
+async def get_package_tree() -> dict:
+    """Get all packages in the APK sorted by class count. Shows total_classes, total_packages, and per-package name, class_count, is_likely_library. Use this first to understand the APK structure before searching."""
+    return await tools.class_tools.get_package_tree()
+
+
+@mcp.tool()
+async def get_cache_stats() -> dict:
+    """Get decompilation cache statistics: hits, misses, hit_rate, cached_classes, compressed_mb, compression_ratio."""
+    return await tools.class_tools.get_cache_stats()
+
+
+@mcp.tool()
+async def clear_cache() -> dict:
+    """Clear the decompilation source cache and reset counters. Use when switching APKs or to free memory."""
+    return await tools.class_tools.clear_cache()
 
 
 @mcp.tool()

--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -12,7 +12,7 @@ See the file 'LICENSE' for copying permission
 import argparse
 import logging
 import sys
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
 from src.banner import jadx_mcp_server_banner
 from src.server import config, tools
 
@@ -84,9 +84,10 @@ async def get_class_source(class_name: str) -> dict:
 
 
 @mcp.tool()
-async def search_method_by_name(method_name: str) -> dict:
+async def search_method_by_name(method_name: str, ctx: Context = None) -> dict:
     """Search for a method name across all classes."""
-    return await tools.search_tools.search_method_by_name(method_name)
+    report_progress = ctx.report_progress if ctx else None
+    return await tools.search_tools.search_method_by_name(method_name, report_progress=report_progress)
 
 
 @mcp.tool()
@@ -102,6 +103,7 @@ async def search_classes_by_keyword(
     search_in: str = "code",
     offset: int = 0,
     count: int = 20,
+    ctx: Context = None,
 ) -> dict:
     """Search for classes containing a specific keyword with flexible filtering options.
 
@@ -143,8 +145,9 @@ async def search_classes_by_keyword(
     Description: Advanced search tool that finds classes matching a keyword with package filtering
                  and scope targeting capabilities. Use this when you need to find specific code
                  patterns, class names, method names, or other identifiers across the decompiled APK."""
+    report_progress = ctx.report_progress if ctx else None
     return await tools.search_tools.search_classes_by_keyword(
-        search_term, package, search_in, offset, count
+        search_term, package, search_in, offset, count, report_progress=report_progress
     )
 
 

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -86,7 +86,7 @@ def health_ping() -> Union[str, Dict[str, Any]]:
         return {"error": str(e)}
 
 
-async def get_from_jadx(endpoint: str, params: Dict[str, Any] = {}) -> Union[str, Dict[str, Any]]:
+async def get_from_jadx(endpoint: str, params: Dict[str, Any] = None) -> Union[str, Dict[str, Any]]:
     """
     Generic async helper to request data from the JADX plugin.
 
@@ -103,10 +103,11 @@ async def get_from_jadx(endpoint: str, params: Dict[str, Any] = {}) -> Union[str
     Note:
         Automatically handles JSON parsing with fallback to text response
     """
+    params = params or {}
     url = f"{JADX_HTTP_BASE}/{endpoint.lstrip('/')}"
     try:
         async with httpx.AsyncClient(trust_env=False) as client:
-            resp = await client.get(url, params=params, timeout=60)
+            resp = await client.get(url, params=params, timeout=600)
             resp.raise_for_status()
 
             # Try to parse JSON, fallback to text if not valid JSON
@@ -120,7 +121,43 @@ async def get_from_jadx(endpoint: str, params: Dict[str, Any] = {}) -> Union[str
         logger.error(error_msg)
         return {"error": error_msg}
 
-    except Exception as e:
-        error_msg = f"Unexpected error: {str(e)}"
+    except httpx.TimeoutException:
+        error_msg = (
+            f"Request to JADX plugin timed out after 600s for endpoint '{endpoint}'. "
+            "The operation may still be running in JADX-GUI. "
+            "For large APKs, code-level searches can take several minutes."
+        )
         logger.error(error_msg)
         return {"error": error_msg}
+
+    except httpx.ConnectError:
+        error_msg = (
+            f"Cannot connect to JADX plugin at {JADX_HTTP_BASE}. "
+            "Ensure JADX-GUI is running and the AI MCP plugin is active."
+        )
+        logger.error(error_msg)
+        return {"error": error_msg}
+
+    except Exception as e:
+        error_msg = f"Unexpected error communicating with JADX plugin: {type(e).__name__}: {str(e)}"
+        logger.error(error_msg)
+        return {"error": error_msg}
+
+
+async def get_search_progress() -> Dict[str, Any]:
+    """
+    Poll the JADX plugin for current search progress.
+
+    Returns:
+        Dict with keys: state, scanned, total, matches, search_id, operation_type,
+        elapsed_ms.  When state is "failed", also includes "error".
+        Returns {"state": "unknown"} on connection failure.
+    """
+    url = f"{JADX_HTTP_BASE}/search-progress"
+    try:
+        async with httpx.AsyncClient(trust_env=False) as client:
+            resp = await client.get(url, timeout=5)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        return {"state": "unknown"}

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -107,7 +107,7 @@ async def get_from_jadx(endpoint: str, params: Dict[str, Any] = None) -> Union[s
     url = f"{JADX_HTTP_BASE}/{endpoint.lstrip('/')}"
     try:
         async with httpx.AsyncClient(trust_env=False) as client:
-            resp = await client.get(url, params=params, timeout=600)
+            resp = await client.get(url, params=params, timeout=3600)
             resp.raise_for_status()
 
             # Try to parse JSON, fallback to text if not valid JSON
@@ -123,7 +123,7 @@ async def get_from_jadx(endpoint: str, params: Dict[str, Any] = None) -> Union[s
 
     except httpx.TimeoutException:
         error_msg = (
-            f"Request to JADX plugin timed out after 600s for endpoint '{endpoint}'. "
+            f"Request to JADX plugin timed out after 3600s for endpoint '{endpoint}'. "
             "The operation may still be running in JADX-GUI. "
             "For large APKs, code-level searches can take several minutes."
         )
@@ -142,6 +142,26 @@ async def get_from_jadx(endpoint: str, params: Dict[str, Any] = None) -> Union[s
         error_msg = f"Unexpected error communicating with JADX plugin: {type(e).__name__}: {str(e)}"
         logger.error(error_msg)
         return {"error": error_msg}
+
+
+async def post_to_jadx(endpoint: str, params: Dict[str, Any] = None) -> Union[str, Dict[str, Any]]:
+    """
+    Generic async helper to POST to the JADX plugin (for mutating operations like cache-clear).
+    """
+    params = params or {}
+    url = f"{JADX_HTTP_BASE}/{endpoint.lstrip('/')}"
+    try:
+        async with httpx.AsyncClient(trust_env=False) as client:
+            resp = await client.post(url, params=params, timeout=30)
+            resp.raise_for_status()
+            try:
+                return resp.json()
+            except json.JSONDecodeError:
+                return {"response": resp.text}
+    except httpx.ConnectError:
+        return {"error": f"Cannot connect to JADX plugin at {JADX_HTTP_BASE}. Ensure JADX-GUI is running."}
+    except Exception as e:
+        return {"error": f"POST to {endpoint} failed: {type(e).__name__}: {str(e)}"}
 
 
 async def get_search_progress() -> Dict[str, Any]:

--- a/src/server/tools/class_tools.py
+++ b/src/server/tools/class_tools.py
@@ -9,7 +9,7 @@ Author: Jafar Pathan (zinja-coder@github)
 License: See LICENSE file
 """
 
-from src.server.config import get_from_jadx
+from src.server.config import get_from_jadx, post_to_jadx
 from src.PaginationUtils import PaginationUtils
 
 
@@ -173,3 +173,44 @@ async def get_main_activity_class() -> dict:
     Description: Identifies and retrieves the app's entry point activity
     """
     return await get_from_jadx("main-activity")
+
+
+async def get_package_tree() -> dict:
+    """
+    Get a tree of all packages in the APK sorted by class count.
+
+    Returns:
+        dict: Contains total_classes, total_packages, and packages list.
+              Each package has name, class_count, and is_likely_library flag.
+
+    MCP Tool: get_package_tree
+    Description: Lists all packages sorted by size to help focus analysis
+    """
+    return await get_from_jadx("package-tree")
+
+
+async def get_cache_stats() -> dict:
+    """
+    Get decompilation cache statistics.
+
+    Returns:
+        dict: Cache observability data including hits, misses, hit_rate,
+              cached_classes, compressed_mb, original_mb, compression_ratio.
+
+    MCP Tool: get_cache_stats
+    Description: Shows cache performance metrics for decompiled source code
+    """
+    return await get_from_jadx("cache-stats")
+
+
+async def clear_cache() -> dict:
+    """
+    Clear the decompilation cache and reset all counters.
+
+    Returns:
+        dict: Confirmation with post-clear stats.
+
+    MCP Tool: clear_cache
+    Description: Resets the source code cache (use when switching APKs)
+    """
+    return await post_to_jadx("cache-clear")

--- a/src/server/tools/search_tools.py
+++ b/src/server/tools/search_tools.py
@@ -4,12 +4,106 @@ JADX MCP Server - Code Search Tools
 This module provides MCP tools for searching through decompiled Android code,
 enabling discovery of classes, methods, and keywords across the entire APK.
 
+Includes progress-aware search that polls the JADX plugin's /search-progress
+endpoint and reports progress to the MCP client via ctx.report_progress().
+
 Author: Jafar Pathan (zinja-coder@github)
 License: See LICENSE file
 """
 
-from src.server.config import get_from_jadx
+import asyncio
+import logging
+from typing import Optional
+
+from src.server.config import get_from_jadx, get_search_progress
 from src.PaginationUtils import PaginationUtils
+
+logger = logging.getLogger("jadx-mcp-server.search")
+
+
+async def _poll_progress(report_progress, poll_interval: float = 2.0, max_poll_seconds: float = 630.0):
+    """
+    Continuously poll /search-progress and report via MCP progress notifications.
+    Runs as a concurrent task alongside the actual search request.
+
+    Args:
+        report_progress: Callable(progress, total) from FastMCP Context,
+                         or None if no progress reporting is available.
+        poll_interval: Seconds between progress polls.
+        max_poll_seconds: Safety cap — stop polling after this many seconds even
+                          if the search still appears to be running.  Guards against
+                          a crashed search thread leaving the tracker stuck in
+                          "running" state.  Set slightly above the HTTP timeout (600s).
+    """
+    if report_progress is None:
+        return
+
+    last_scanned = -1
+    seen_running = False
+    consecutive_failures = 0
+    # After we've confirmed the search is active (seen_running), a dead server
+    # is a real problem.  Before that, be more tolerant — the plugin may still
+    # be initialising or the search hasn't started yet.
+    MAX_FAILURES_BEFORE_RUNNING = 10   # ~20 seconds of tolerance during startup
+    MAX_FAILURES_AFTER_RUNNING = 3     # ~6 seconds — server died mid-search
+    loop = asyncio.get_running_loop()
+    poll_start = loop.time()
+    try:
+        while True:
+            await asyncio.sleep(poll_interval)
+
+            # Safety: abort polling if we've exceeded the time cap
+            if (loop.time() - poll_start) > max_poll_seconds:
+                logger.warning("Progress poller: max poll time (%.0fs) exceeded, stopping", max_poll_seconds)
+                break
+
+            progress = await get_search_progress()
+            # Java sends state in lowercase: "idle", "running", "completed", "failed"
+            state = progress.get("state", "unknown")
+
+            if state == "unknown":
+                # Poll failed — server may be unreachable
+                consecutive_failures += 1
+                threshold = MAX_FAILURES_AFTER_RUNNING if seen_running else MAX_FAILURES_BEFORE_RUNNING
+                if consecutive_failures >= threshold:
+                    logger.error(
+                        "Progress poller: JADX plugin unreachable after %d consecutive poll failures "
+                        "(seen_running=%s). Stopping progress updates. "
+                        "The main search request will report its own error when it times out.",
+                        consecutive_failures, seen_running,
+                    )
+                    break
+                continue
+
+            # Successful poll — reset failure counter
+            consecutive_failures = 0
+
+            if state == "running":
+                seen_running = True
+                scanned = progress.get("scanned", 0)
+                total = progress.get("total", 0)
+                if total > 0 and scanned != last_scanned:
+                    last_scanned = scanned
+                    try:
+                        await report_progress(scanned, total)
+                    except Exception:
+                        pass  # Client may not support progress
+
+            elif seen_running and state in ("completed", "failed"):
+                # Current search finished — send final progress and stop
+                scanned = progress.get("scanned", 0)
+                total = progress.get("total", 0)
+                if total > 0:
+                    try:
+                        await report_progress(scanned, total)
+                    except Exception:
+                        pass
+                break
+            # If not seen_running yet: state might be "idle", "completed", or
+            # "failed" from a PREVIOUS search — keep polling until the current
+            # search sets state to "running".
+    except asyncio.CancelledError:
+        pass
 
 
 async def get_method_by_name(class_name: str, method_name: str) -> dict:
@@ -31,20 +125,30 @@ async def get_method_by_name(class_name: str, method_name: str) -> dict:
     )
 
 
-async def search_method_by_name(method_name: str) -> dict:
+async def search_method_by_name(method_name: str, report_progress=None) -> dict:
     """
     Search for a method name across all classes.
+    Now uses metadata-based search (no decompilation) on the Java side,
+    and reports progress if a report_progress callback is provided.
 
     Args:
         method_name: Method name to search for (partial matching supported)
+        report_progress: Optional async callable(progress, total) from FastMCP Context
 
     Returns:
         dict: List of all classes containing methods with matching names
-
-    MCP Tool: search_method_by_name
-    Description: Finds all occurrences of a method name across the APK
     """
-    return await get_from_jadx("search-method", {"method_name": method_name})
+    # Fire search request and progress poller concurrently
+    progress_task = asyncio.create_task(_poll_progress(report_progress))
+    try:
+        result = await get_from_jadx("search-method", {"method_name": method_name})
+    finally:
+        progress_task.cancel()
+        try:
+            await progress_task
+        except asyncio.CancelledError:
+            pass
+    return result
 
 
 async def search_classes_by_keyword(
@@ -53,6 +157,7 @@ async def search_classes_by_keyword(
     search_in: str = "code",
     offset: int = 0,
     count: int = 20,
+    report_progress=None,
 ) -> dict:
     """
     Search for classes containing a specific keyword with flexible filtering options.
@@ -87,25 +192,30 @@ async def search_classes_by_keyword(
 
         offset (optional): Starting index for pagination. Default: 0
         count (optional): Maximum number of results to return. Default: 20
+        report_progress: Optional async callable(progress, total) from FastMCP Context
 
     Returns:
         dict: Paginated list of classes containing the search term, with metadata about matches
-
-    MCP Tool: search_classes_by_keyword
-    Description: Advanced search tool that finds classes matching a keyword with package filtering
-                 and scope targeting capabilities. Use this when you need to find specific code
-                 patterns, class names, method names, or other identifiers across the decompiled APK.
-
     """
-    return await PaginationUtils.get_paginated_data(
-        endpoint="search-classes-by-keyword",
-        offset=offset,
-        count=count,
-        additional_params={
-            "search_term": search_term,
-            "package": package,
-            "search_in": search_in,
-        },
-        data_extractor=lambda parsed: parsed.get("classes", []),
-        fetch_function=get_from_jadx,
-    )
+    # Fire search request and progress poller concurrently
+    progress_task = asyncio.create_task(_poll_progress(report_progress))
+    try:
+        result = await PaginationUtils.get_paginated_data(
+            endpoint="search-classes-by-keyword",
+            offset=offset,
+            count=count,
+            additional_params={
+                "search_term": search_term,
+                "package": package,
+                "search_in": search_in,
+            },
+            data_extractor=lambda parsed: parsed.get("classes", []),
+            fetch_function=get_from_jadx,
+        )
+    finally:
+        progress_task.cancel()
+        try:
+            await progress_task
+        except asyncio.CancelledError:
+            pass
+    return result

--- a/src/server/tools/search_tools.py
+++ b/src/server/tools/search_tools.py
@@ -21,19 +21,38 @@ from src.PaginationUtils import PaginationUtils
 logger = logging.getLogger("jadx-mcp-server.search")
 
 
-async def _poll_progress(report_progress, poll_interval: float = 2.0, max_poll_seconds: float = 630.0):
+async def _poll_progress(
+    report_progress,
+    poll_interval: float = 2.0,
+    budget_seconds: float = 600.0,
+    absolute_max_seconds: float = 3600.0,
+    extension_threshold: float = 0.90,
+    cancel_search_event: Optional[asyncio.Event] = None,
+):
     """
     Continuously poll /search-progress and report via MCP progress notifications.
     Runs as a concurrent task alongside the actual search request.
+
+    Implements a **dynamic timeout**: starts with an initial budget (default 600s).
+    When the elapsed time reaches extension_threshold (90%) of the current budget
+    AND the search is still running, the poller asks the plugin for its state.
+    If the plugin confirms it is still searching, the budget is extended by the
+    original amount (e.g. +600s).  Extensions repeat until the search finishes
+    or the absolute_max_seconds ceiling is reached.
+
+    If cancel_search_event is provided and gets set, the poller will signal that
+    the main HTTP request should be abandoned (the caller should cancel the task).
 
     Args:
         report_progress: Callable(progress, total) from FastMCP Context,
                          or None if no progress reporting is available.
         poll_interval: Seconds between progress polls.
-        max_poll_seconds: Safety cap — stop polling after this many seconds even
-                          if the search still appears to be running.  Guards against
-                          a crashed search thread leaving the tracker stuck in
-                          "running" state.  Set slightly above the HTTP timeout (600s).
+        budget_seconds: Initial time budget for the search.  When ~90% consumed,
+                        the poller checks status and may extend.
+        absolute_max_seconds: Hard ceiling — never extend beyond this total.
+        extension_threshold: Fraction (0-1) of budget at which to evaluate extension.
+        cancel_search_event: If set, the poller will set() this event to signal
+                             the caller to cancel the HTTP request.
     """
     if report_progress is None:
         return
@@ -41,6 +60,9 @@ async def _poll_progress(report_progress, poll_interval: float = 2.0, max_poll_s
     last_scanned = -1
     seen_running = False
     consecutive_failures = 0
+    original_budget = budget_seconds
+    current_deadline = budget_seconds
+    extensions_granted = 0
     # After we've confirmed the search is active (seen_running), a dead server
     # is a real problem.  Before that, be more tolerant — the plugin may still
     # be initialising or the search hasn't started yet.
@@ -52,9 +74,63 @@ async def _poll_progress(report_progress, poll_interval: float = 2.0, max_poll_s
         while True:
             await asyncio.sleep(poll_interval)
 
-            # Safety: abort polling if we've exceeded the time cap
-            if (loop.time() - poll_start) > max_poll_seconds:
-                logger.warning("Progress poller: max poll time (%.0fs) exceeded, stopping", max_poll_seconds)
+            elapsed = loop.time() - poll_start
+
+            # hard ceiling, no more extensions possible
+            if elapsed > absolute_max_seconds:
+                logger.warning(
+                    "Progress poller: absolute max time (%.0fs) reached after %d extensions. Stopping.",
+                    absolute_max_seconds, extensions_granted,
+                )
+                if cancel_search_event:
+                    cancel_search_event.set()
+                break
+
+            # dynamic timeout check: approaching the current deadline?
+            if elapsed >= current_deadline * extension_threshold and seen_running:
+                # Ask the plugin: "Are you still searching?"
+                check = await get_search_progress()
+                check_state = check.get("state", "unknown")
+                if check_state == "running":
+                    # plugin confirms it's still working => grant extension
+                    new_deadline = current_deadline + original_budget
+                    if new_deadline > absolute_max_seconds:
+                        new_deadline = absolute_max_seconds
+                    extensions_granted += 1
+                    logger.info(
+                        "Progress poller: search still running at %.0fs (%.0f%% of budget). "
+                        "Extending deadline by %.0fs → new deadline %.0fs (extension #%d).",
+                        elapsed, (elapsed / current_deadline) * 100,
+                        original_budget, new_deadline, extensions_granted,
+                    )
+                    try:
+                        # inform the MCP client about the extension
+                        scanned = check.get("scanned", 0)
+                        total = check.get("total", 0)
+                        if total > 0:
+                            await report_progress(scanned, total)
+                    except Exception:
+                        pass
+                    current_deadline = new_deadline
+                elif check_state in ("completed", "failed"):
+                    # Search ended while we were checking ,will be caught below
+                    pass
+                else:
+                    # plugin unreachable near deadline , not safe to extend
+                    logger.warning(
+                        "Progress poller: budget nearly exhausted at %.0fs and plugin state "
+                        "is '%s'. Not extending.",
+                        elapsed, check_state,
+                    )
+
+            # Past the current deadline (after extension opportunities), give up
+            if elapsed > current_deadline:
+                logger.warning(
+                    "Progress poller: deadline (%.0fs) exceeded with %d extensions granted. Stopping.",
+                    current_deadline, extensions_granted,
+                )
+                if cancel_search_event:
+                    cancel_search_event.set()
                 break
 
             progress = await get_search_progress()


### PR DESCRIPTION
Problem:
- Searches against large APKs (173K+ classes) failed with an empty 'Unexpected error' message because httpx used a 60s default timeout and str(ReadTimeout()) produces an empty string
- No visibility into long-running search progress for MCP clients
- No detection of server crashes during search operations

Changes:

1. Increase HTTP timeout and improve error handling (config.py)
   - Raise httpx timeout from 60s to 600s to accommodate large APK searches
   - Add explicit httpx.TimeoutException catch with descriptive message including the URL that timed out
   - Add explicit httpx.ConnectError catch for server-unreachable scenarios
   - Fix mutable default argument: params=None with params=params or {}
   - Add get_search_progress() helper to poll the new /search-progress endpoint, returning {'state': 'unknown'} on any failure

2. Add concurrent progress polling to search tools (search_tools.py)
   - Add _poll_progress() async coroutine that polls /search-progress every 2 seconds during active searches
   - Reports progress to MCP clients via ctx.report_progress() using scanned/total counters from the Java server
   - Logs human-readable progress with percentage and match count
   - seen_running guard prevents stale-completed race condition where the poller could exit immediately on leftover 'completed' state from a previous search
   - Server-alive detection with consecutive failure tracking: MAX_FAILURES_BEFORE_RUNNING=10 (~20s grace period for search startup) MAX_FAILURES_AFTER_RUNNING=3 (~6s to detect server crash mid-search)
   - Safety cap of max_poll_seconds=630s to prevent infinite polling
   - Uses asyncio monotonic time for reliable duration tracking

3. Inject MCP Context into search endpoints (jadx_mcp_server.py)
   - Import Context from fastmcp
   - search_classes_by_keyword and search_method_by_name now accept optional ctx: Context parameter
   - Pass ctx.report_progress callback to _poll_progress() when context is available

Tested against an APK with 173K classes:
- class_name search: 3 results in 0.25s (metadata-only)
- code search: 109 results, completed without timeout
- method search (onCreate): 1000+ results, instant response