### PR TITLE
fix: keep stdout clean for stdio clients and forward class_name on rename

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -263,9 +263,16 @@ async def rename_class(class_name: str, new_name: str) -> dict:
 
 
 @mcp.tool()
-async def rename_method(method_name: str, new_name: str, method_signature: str = None) -> dict:
-    """Renames a specific method."""
-    return await tools.refactor_tools.rename_method(method_name, new_name, method_signature)
+async def rename_method(
+    method_name: str,
+    new_name: str,
+    class_name: str = None,
+    method_signature: str = None,
+) -> dict:
+    """Renames a specific method, optionally scoped to class_name."""
+    return await tools.refactor_tools.rename_method(
+        method_name, new_name, class_name, method_signature
+    )
 
 
 @mcp.tool()
@@ -397,7 +404,9 @@ def main():
         mcp.run(transport="streamable-http", host=args.host, port=args.port)
     else:
         # StdIO transport must keep stdout reserved for MCP frames.
-        mcp.run()
+        # FastMCP's startup banner can pollute stdio MCP handshakes in some clients.
+        # Keep banner disabled for deterministic stdio initialization (issue #60).
+        mcp.run(show_banner=False)
 
 
 if __name__ == "__main__":

--- a/src/server/tools/refactor_tools.py
+++ b/src/server/tools/refactor_tools.py
@@ -29,13 +29,19 @@ async def rename_class(class_name: str, new_name: str) -> dict:
     return await get_from_jadx("rename-class", {"class_name": class_name, "new_name": new_name})
 
 
-async def rename_method(method_name: str, new_name: str, method_signature: str = None) -> dict:
+async def rename_method(
+    method_name: str,
+    new_name: str,
+    class_name: str = None,
+    method_signature: str = None,
+) -> dict:
     """
     Renames a specific method.
 
     Args:
         method_name: Current method name (can include signature)
         new_name: New name for the method
+        class_name: Optional fully qualified class name to scope the rename
         method_signature: Optional method signature/descriptor (e.g. '(I)V') to distinguish overloads
 
     Returns:
@@ -45,6 +51,8 @@ async def rename_method(method_name: str, new_name: str, method_signature: str =
     Description: Refactors method name and updates all call sites
     """
     params = {"method_name": method_name, "new_name": new_name}
+    if class_name:
+        params["class_name"] = class_name
     if method_signature:
         params["method_signature"] = method_signature
     return await get_from_jadx("rename-method", params)


### PR DESCRIPTION
## Summary

**Codex CLI cannot start the server (#60, zinja-coder/jadx-ai-mcp#104).** FastMCP prints its startup banner to stdout, which corrupts the stdio frame stream and breaks the MCP `initialize` handshake. `show_banner=False` was proposed in #51 but was lost in merge `605429d`, so the stdio path regressed. Restored on the stdio branch only — the HTTP path is unaffected.

Multiple users independently arrived at this same one-line patch, so this closes the loop on both reports.

**`class_name` plumbing.** `rename_method` forwards the new optional `class_name` argument through to the plugin, so a rename can be scoped to a single class. Pairs with zinja-coder/jadx-ai-mcp#109, which adds the plugin-side handling.

closes #60
closes zinja-coder/jadx-ai-mcp#104
