### PR TITLE
release: v6.4.1

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -389,7 +389,7 @@ def main():
         logger.info(jadx_mcp_server_banner())
     except Exception:
         logger.info(
-            "[JADX AI MCP Server] v3.3.5 | MCP Port: %s | JADX Host: %s | JADX Port: %s",
+            "[JADX AI MCP Server] v6.4.1 | MCP Port: %s | JADX Host: %s | JADX Port: %s",
             args.port,
             args.jadx_host,
             args.jadx_port,

--- a/src/banner.py
+++ b/src/banner.py
@@ -24,6 +24,6 @@ def jadx_mcp_server_banner() -> str:
             
             Author         -> Jafar Pathan (zinja-coder@github)
             For Issues     -> https://github.com/zinja-coder/jadx-mcp-server
-            Server Version -> v6.4.0
+            Server Version -> v6.4.1
             
           """


### PR DESCRIPTION
## Summary

Version bump for the fixes merged in #61. These lines were pushed to the #61 branch after it was opened, but GitHub never advanced the PR head, so they were not part of the merge.

- `src/banner.py` - startup banner now reports v6.4.1
- `jadx_mcp_server.py` - the fallback startup log had been hardcoded to **v3.3.5** for several releases and disagreed with the banner whenever the Unicode banner failed to render. Now matches.
