### PR TITLE
fix: allow Python 3.10+ for package installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "jadx-mcp-server"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=3.0.2",
     "httpx>=0.28.1",


### PR DESCRIPTION
## Problem

`pyproject.toml` declares `requires-python = ">=3.13"`. This value has been present since the initial commit (`efac9e1`, beta v0.0.1) and appears to be an unmodified `uv init` default rather than a deliberate constraint.

It conflicts with the two other places the project states its Python requirement:

- `README.md` badge: **Python 3.10+**
- `jadx_mcp_server.py` PEP 723 inline metadata: `requires-python = ">=3.10"`

The practical effect is that script mode (`uv run jadx_mcp_server.py`) works on Python 3.10, but `uv tool install` / `pip install` of the package fails on 3.10–3.12 for no technical reason.

## Change

```diff
-requires-python = ">=3.13"
+requires-python = ">=3.10"
```

## Verification

Tested against a real CPython **3.10.18** interpreter, not just a static check:

| Check | Result |
|---|---|
| Resolve + install `fastmcp>=3.0.2`, `httpx>=0.28.1`, `requests>=2.32.3` | pass - fastmcp resolved to 3.4.6 |
| `compileall` over every source file | pass, exit 0 |
| Import `jadx_mcp_server` module | pass, `FastMCP` instance constructed |
| MCP tool registration | pass, all **32** tools registered |
| Scan for 3.11+/3.12+ only syntax and stdlib APIs | none found |

The scan covered `tomllib`, `ExceptionGroup` / `except*`, `typing.Self`, `datetime.UTC`, `enum.StrEnum`, `asyncio.TaskGroup`, `itertools.batched`, `@override`, and PEP 695 generics. The codebase uses none of them.

`fastmcp` itself declares `requires-python = ">=3.10"` for both the 3.0.2 floor and current 3.4.6, so the dependency chain imposes no higher floor either.

## Impact

Restores installability for Python 3.10–3.12 users and makes `pyproject.toml`, the README badge, and the PEP 723 header agree.