### PR TITLE
docs: credit v6.4.1 issue reporters as contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,51 @@ Thanks to these wonderful people for their contributions ⭐
     <td>
       <a href="https://github.com/LilNick0101">
         <img src="https://avatars.githubusercontent.com/u/100995805?v=4" width="30px;" alt=""/>
-        <br /><sub><b>LikNick0101</b></sub>
+        <br /><sub><b>LilNick0101</b></sub>
       </a>
     </td>
     <td>
       <a href="https://github.com/lwsinclair">
         <img src="https://avatars.githubusercontent.com/u/2829939?v=4" width="30px;" alt=""/>
         <br /><sub><b>lwsinclair</b></sub>
+      </a>
+    </td>
+  </tr>
+  <tr align="center">
+    <td>
+      <a href="https://github.com/LYC-Android">
+        <img src="https://avatars.githubusercontent.com/u/18358825?v=4" width="30px;" alt=""/>
+        <br /><sub><b>LYC-Android</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/zbhello">
+        <img src="https://avatars.githubusercontent.com/u/122980705?v=4" width="30px;" alt=""/>
+        <br /><sub><b>zbhello</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/1yearning1">
+        <img src="https://avatars.githubusercontent.com/u/297883149?v=4" width="30px;" alt=""/>
+        <br /><sub><b>1yearning1</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/mhsjzsq">
+        <img src="https://avatars.githubusercontent.com/u/116739454?v=4" width="30px;" alt=""/>
+        <br /><sub><b>mhsjzsq</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/darkblack1234">
+        <img src="https://avatars.githubusercontent.com/u/139411545?v=4" width="30px;" alt=""/>
+        <br /><sub><b>darkblack1234</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Merrg1n">
+        <img src="https://avatars.githubusercontent.com/u/22628584?v=4" width="30px;" alt=""/>
+        <br /><sub><b>Merrg1n</b></sub>
       </a>
     </td>
   </tr>


### PR DESCRIPTION
## Why

Mirrors zinja-coder/jadx-ai-mcp#112. Every fix in v6.4.1 originated from a community bug report, and two of the six reporters filed against this repository directly:

- [darkblack1234](https://github.com/darkblack1234) — #59, `ClassCastException: ResourceFile cannot cast to ICodeInfo`. Gave an exact repro against a Spring Boot jar and correctly predicted the bug would generalize to other `ResourceFile`-backed resources, which it did.
- [Merrg1n](https://github.com/Merrg1n) — #60, stdio handshake failure with Codex CLI. Traced `show_banner=False` back to PR #51 and found it had been silently dropped in merge `605429d`, turning an apparent new bug into a known regression.

The other four ([LYC-Android](https://github.com/LYC-Android), [mhsjzsq](https://github.com/mhsjzsq), [1yearning1](https://github.com/1yearning1), [zbhello](https://github.com/zbhello)) filed on the plugin repo, but two of their fixes landed partly here — `rename_method` gained `class_name` in `refactor_tools.py`, and the stdio banner fix is server-side. Both READMEs have historically carried the same contributor list, so they are added here too.

## Change

Adds a second `<tr>` to the contributors table rather than extending the first row, which was already 17 wide.

Also fixes a display-name typo: one entry read `LikNick0101` while linking to the correct `LilNick0101` profile.

Markup validated: balanced `<tr>`/`<td>` tags, 23 entries, all avatar and profile URLs return HTTP 200.
