### PR TITLE
fix: exit cleanly on stdio keyboard interrupt

### DIFF
--- a/jadx_mcp_server.py
+++ b/jadx_mcp_server.py
@@ -406,7 +406,10 @@ def main():
         # StdIO transport must keep stdout reserved for MCP frames.
         # FastMCP's startup banner can pollute stdio MCP handshakes in some clients.
         # Keep banner disabled for deterministic stdio initialization (issue #60).
-        mcp.run(show_banner=False)
+        try:
+            mcp.run(show_banner=False)
+        except KeyboardInterrupt:
+            logger.info("JADX MCP server interrupted; exiting cleanly")
 
 
 if __name__ == "__main__":

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,29 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+import jadx_mcp_server
+
+
+class ShutdownTests(unittest.TestCase):
+    def test_main_exits_cleanly_when_fastmcp_is_interrupted(self):
+        with (
+            patch.object(sys, "argv", ["jadx_mcp_server.py"]),
+            patch.object(jadx_mcp_server.config, "health_ping", return_value="ok"),
+            patch.object(
+                jadx_mcp_server.mcp, "run", side_effect=KeyboardInterrupt
+            ),
+            self.assertLogs("jadx-mcp-server.bootstrap", level="INFO") as logs,
+        ):
+            try:
+                jadx_mcp_server.main()
+            except KeyboardInterrupt:
+                self.fail("main() propagated KeyboardInterrupt")
+
+        self.assertIn(
+            "JADX MCP server interrupted; exiting cleanly", logs.output[-1]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- catch `KeyboardInterrupt` at the stdio FastMCP boundary
- log a concise clean-shutdown message instead of emitting the AnyIO cancellation traceback
- add a regression test for the CLI entry point

## Context

FastMCP currently lets `KeyboardInterrupt` escape from its synchronous `run()` wrapper. On Windows, stopping an MCP host with Ctrl+C can therefore make this stdio server print a full `WouldBlock -> CancelledError -> KeyboardInterrupt` traceback even though shutdown was intentional.

The handler is deliberately scoped to the stdio branch. Other exceptions still propagate, and the HTTP transport is unchanged.

Related upstream reports:
- https://github.com/PrefectHQ/fastmcp/issues/2837
- https://github.com/modelcontextprotocol/python-sdk/issues/2663

## Validation

- `.venv/Scripts/python.exe -m unittest discover -s tests -v`
- `.venv/Scripts/python.exe -m compileall -q jadx_mcp_server.py src tests`
- `git diff --check`
